### PR TITLE
Class "main" converted in ID "main"

### DIFF
--- a/db_style.css
+++ b/db_style.css
@@ -17,7 +17,7 @@ div.code {
 	padding: 5px 10px 5px 10px;
 	border-width: 1px;
 }
-div.main {
+#main {
 	font-family: 'Open Sans', "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
   max-width: 50em;
   background-color:#fff;

--- a/download.html
+++ b/download.html
@@ -10,7 +10,7 @@
 	</head>
 
 	<body>
-		<div class="main">
+		<div id="main">
 			<div class="titlepage">
 				<a href="index.html"><h1>FidoCadJ</h1></a>
 				<h2>a free graphical editor for (more than) electronics</h2>

--- a/examples.html
+++ b/examples.html
@@ -10,7 +10,7 @@
 	</head>
 
 <body>
-	<div class="main">
+	<div id="main">
 
 		<div class="titlepage">
 			<a href="index.html"><h1>FidoCadJ</h1></a>

--- a/faq.html
+++ b/faq.html
@@ -9,7 +9,7 @@
 	</head>
 
 	<body>
-		<div class="main">
+		<div id="main">
 			<div class="titlepage">
 				<a href="index.html"><h1>FidoCadJ</h1></a>
 				<h2>a free graphical editor for (more than) electronics</h2>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 	</head>
 
 	<body>
-		<div class="main">
+		<div id="main">
 			<div class="titlepage">
 				<a href="index.html"><h1>FidoCadJ</h1></a>
 				<h2>a free graphical editor for (more than) electronics</h2>

--- a/libs.html
+++ b/libs.html
@@ -10,7 +10,7 @@
 	</head>
 
 	<body>
-		<div class="main">
+		<div id="main">
 			<div class="titlepage">
 				<a href="index.html"><h1>FidoCadJ</h1></a>
 				<h2>a free graphical editor for (more than) electronics</h2>

--- a/scrn.html
+++ b/scrn.html
@@ -10,7 +10,7 @@
 	</head>
 
 	<body>
-		<div class="main">
+		<div id="main">
 			<div class="titlepage">
 				<a href="index.html"><h1>FidoCadJ</h1></a>
 				<h2>a free graphical editor for (more than) electronics</h2>


### PR DESCRIPTION
"main" div is one element per page, so we don't need to use a class
attrib. CSS selector was changed from ".main" in "#main"

I'm not sure we are going to keep a general div just inside the body
element. May be more efficient use the body element css rule directly,
instead of creating a child element.