### PR TITLE
FAQ page navigation improvement

### DIFF
--- a/db_style.css
+++ b/db_style.css
@@ -144,3 +144,16 @@ span.command {
  	font-family: monospace;
  	font-size: 120%;
 }
+#faq_index a{
+	color:#444;
+	line-height: 2em;
+	text-decoration: underline;
+}
+.faq_title{
+	color:#444;
+}
+.go_top_label{
+	float: right;
+	margin-right: 20px;
+	font-size: 1em;
+}

--- a/faq.html
+++ b/faq.html
@@ -30,29 +30,55 @@
 			</div>
 
 			<h3>Frequently asked questions</h3>
+			<ul id="faq_index">
+				<li><a href="#1">What is FidoCadJ?</a></li>
+				<li><a href="#2">Can I use FidoCadJ for other than electronics?</a></li>
+				<li><a href="#3">How much does FidoCadJ cost?</a></li>
+				<li><a href="#4">What are the requirements to run FidoCadJ?</a></li>
+				<li><a href="#5">How can I rotate/mirror symbols?</a></li>
+				<li><a href="#6">Why is FidoCadJ useful in my forum/website?</a></li>
+				<li><a href="#7">I already use Kicad, LTSpice, Cadence, Mentor, Altium or Visio, why is FidoCadJ interesting?</a></li>
+				<li><a href="#8">FidoCadJ does not run or is very slow, what can I do?</a></li>
+				<li><a href="#9">Version number is 0.something. Is it an unstable/unfinished project?</a></li>
+				<li><a href="#10">How can I participate to the development?</a></li>
+			</ul>
 
-			<h4>What is FidoCadJ?</h4>
+			<h4><a class="faq_title" name="1">What is FidoCadJ?</a></h4>
 			<p>FidoCadJ is a <b>simple</b> vector graphic editor. You can draw whatever you want, and FidoCadJ comes with a large library of symbols related to the electrical and electronic engineering.</p>
-			<h4>Can I use FidoCadJ for other than electronics?</h4>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="2">Can I use FidoCadJ for other than electronics?</a></h4>
 			<p>Yes, you can! FidoCadJ can be used in <a href="http://www.matematicamente.it/forum/viewtopic.php?f=38&t=114624">diagrams</a>, <a href="http://www.electroyou.it/pepito/wiki/libreria-flowchart-per-fidocadj">flow-charts</a> and <a href="http://www.electroyou.it/admin/wiki/peanuts-fidocadj">even comics</a>. In the <a href="scrn.html">screenshots</a> you have some examples.</p>
-			<h4>How much does FidoCadJ cost?</h4>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="3">How much does FidoCadJ cost?</a></h4>
 			<p>Nothing. Zero. Nil. FidoCadJ is <b>Free Software</b>, released under the General Public License version 3.</p>
-			<h4>What are the requirements to run FidoCadJ?</h4>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="4">What are the requirements to run FidoCadJ?</a></h4>
 			<p>You need a computer with Java 1.7 installed. Any operating system will do (Windows, Linux, MacOSX,...). You can also run FidoCadJ on an Android tablet or cellular phone (version 4.0 at least is required).</p>
-			<h4>How can I rotate/mirror symbols?</h4>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="5">How can I rotate/mirror symbols?</a></h4>
 			<p>Press R or S while editing them. You also have Rotate/Mirror among the Edit menu items.</p>
-			<h4>Why is FidoCadJ useful in my forum/website?</h4>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="6">Why is FidoCadJ useful in my forum/website?</a></h4>
 			<p>You can share the source code of the drawings. It is a simple plain text format completely described in the FidoCadJ user manual. Your users can pick it up, modifying the drawings as they wish and then upload them again.</p>
-			<h4>I already use Kicad, LTSpice, Cadence, Mentor, Altium or Visio, why is FidoCadJ interesting?</h4>
-			<p>Because it is a <b>different program</b> pursuing different purposes. It is complementary with the big EDA electronic tools. Ever tried to include your schematics in a document or in a presentation? Were you happy of the result? If you want to publish and share your drawings and you are not interested in the netlist features and simulation, FidoCadJ may be the tool for you. It is LaTeX-friendly: you can export drawings in a PGF/TikZ script to be included in your document.</p>
-			<h4>FidoCadJ does not run or is very slow, what can I do?</h4>
-			<p>Most of the times, if you can not run FidoCadJ in your system, this means that Java is not correctly installed. If FidoCadJ runs, but is abnormally slow, this might indicate that the configuration of Java is not optimal. It happened in the past with some Linux distributions, that suboptimal graphic drivers gave disappointing rendering performance with Java. If other Java applications run perfectly fine, <a href="https://sourceforge.net/p/fidocadj/discussion/?source=navbar">contact us on the forum</a>.</p>
-			<h4>Version number is 0.something. Is it an unstable/unfinished project?</h4>
-			<p>FidoCadJ is nowadays quite <b>mature</b>. The fact that version number begins with a zero has nothing to do with that. It is just a convention. Unstable/developer versions are instead followed by a greek letter. You can try them, but you are warned that some bugs might sneak here and there.</p>
-			<h4>How can I participate to the development?</h4>
-			<p>FidoCadJ is an <b>open source</b> project. You can freely have a look at the <a href="https://sourceforge.net/p/fidocadj/code/HEAD/tree/">complete source code in the SVN repository</a>. Also this website is kept in the repository. You can review the code, spot bugs, suggest improvements in the application or in the documentation. Becoming an active contributor, with write access on the repository, requires you to read the <a href="https://sourceforge.net/p/fidocadj/code/HEAD/tree/trunk/README">README</a> file, and discuss a little with the other developers on the <a href="https://sourceforge.net/p/fidocadj/discussion/?source=navbar">Sourceforge web forum</a>.</p>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="7">I already use Kicad, LTSpice, Cadence, Mentor, Altium or Visio, why is FidoCadJ interesting?</a></h4>
+			<p>Because it is a <b>different program</b> pursuing different purposes. It is complementary with the big EDA electronic tools. Ever tried to include your schematics in a document or in a presentation? Were you happy of the result?</p>
+			<p>If you want to publish and share your drawings and you are not interested in the netlist features and simulation, FidoCadJ may be the tool for you. It is LaTeX-friendly: you can export drawings in a PGF/TikZ script to be included in your document.</p>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="8">FidoCadJ does not run or is very slow, what can I do?</a></h4>
+			<p>Most of the times, if you can not run FidoCadJ in your system, this means that Java is not correctly installed. If FidoCadJ runs, but is abnormally slow, this might indicate that the configuration of Java is not optimal.</p>
+			<p>It happened in the past with some Linux distributions, that suboptimal graphic drivers gave disappointing rendering performance with Java. If other Java applications run perfectly fine, <a href="https://sourceforge.net/p/fidocadj/discussion/?source=navbar">contact us on the forum</a>.</p>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="9">Version number is 0.something. Is it an unstable/unfinished project?</a></h4>
+			<p>FidoCadJ is nowadays quite <b>mature</b>. The fact that version number begins with a zero has nothing to do with that. It is just a convention. Unstable/developer versions are instead followed by a greek letter.</p>
+			<p>You can try them, but you are warned that some bugs might sneak here and there.</p>
+			<a class="go_top_label" href="#top">top</a></br>
+			<h4><a class="faq_title" name="10">How can I participate to the development?</a></h4>
+			<p>FidoCadJ is an <b>open source</b> project. You can freely have a look at the <a href="https://github.com/DarwinNE/FidoCadJ">complete source code in the GitHub repository</a>. Also this website is kept in the repository.</p>
+			<p>You can review the code, spot bugs, suggest improvements in the application or in the documentation. Becoming an active contributor, with write access on the repository, requires you to read the <a href="https://github.com/DarwinNE/FidoCadJ/blob/master/README">README</a> file, and discuss a little with the other developers on the <a href="https://sourceforge.net/p/fidocadj/discussion/?source=navbar">Sourceforge web forum</a>.</p>
+			<a class="go_top_label" href="#top">top</a>
 
-			<p>October, 5, 2014</p><br>
+			<p>August, 11, 2015</p><br>
 
 			<h3>License</h3>
 			<img src="logos/gplv3-127x51.png" alt="GPL v. 3" class="float">


### PR DESCRIPTION
Is difficoult scroll a ton of content on a mobile device screen, so I
added a navigation system on the faq page.

It's composed by an index and the classic top button to go back on top
of the page.

Couse a big question needs a big answer, I separate some wall of text in
2 paragraph for the sake of readability.

It's not a big deal on desktop, but on mobile it is.

I added the necessary CSS code to style a little bit.

NOTE: some links were ponting to the old repository website, I've update
but still don't know what use to substitute the forum links. Let me
know.