### PR TITLE
Added Meta tag "description" to all html pages

### DIFF
--- a/download.html
+++ b/download.html
@@ -5,6 +5,7 @@
 		<link href="db_style.css" rel="stylesheet">
 		<meta charset="UTF-8">
 		<meta name=viewport content="width=device-width, initial-scale=1">
+		<meta name="description" content="Download FidoCadJ for absolutely free. No registration is request. Available for Windows, MacOSX, Linux and Android. Join us in the developement on GitHub!">
 		<link rel="icon" href="images/FidoCadJ_favicon.png" />
 		<title>FidoCadJ Download</title>
 	</head>
@@ -208,7 +209,7 @@
 				</tr>
 			</table>
 
-			<p>June 8, 2015</p><br>
+			<p>August 17, 2015</p><br>
 
 			<h3>License</h3>
 			<img src="images/logos/gplv3-127x51.png" alt="GPL v. 3" class="float">

--- a/examples.html
+++ b/examples.html
@@ -5,6 +5,7 @@
 		<link href="db_style.css" rel="stylesheet">
 		<meta charset="UTF-8">
 		<meta name=viewport content="width=device-width, initial-scale=1">
+		<meta name="description" content="Examples of FidoCadJ code and capabilities. Draw electrical stuffs from the schema to the pcb footprint. The FidoCadJ file format is easy to use and very light.">
 		<link rel="icon" href="images/FidoCadJ_favicon.png" />
 		<title>FidoCadJ Examples</title>
 	</head>
@@ -982,7 +983,7 @@ TY 70 225 14 8 0 0 3 * C12
 					</tr>
 				</table>
 
-			 	<p>October, 5, 2014</p><br>
+			 	<p>August, 17, 2015</p><br>
 
 				<h3>License</h3>
 				<img src="images/logos/gplv3-127x51.png" alt="GPL v. 3" class="float">

--- a/faq.html
+++ b/faq.html
@@ -4,6 +4,7 @@
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,700' rel='stylesheet'>
 		<link href="db_style.css" rel="stylesheet">
 		<meta charset="UTF-8">
+		<meta name="description" content="Frequently asked questions about FidoCadJ and how it works. How to download and easily use the free software to draw and share your project.">
 		<link rel="icon" href="images/FidoCadJ_favicon.png" />
 		<title>FidoCadJ Frequently Asked Questions</title>
 	</head>
@@ -78,7 +79,7 @@
 			<p>You can review the code, spot bugs, suggest improvements in the application or in the documentation. Becoming an active contributor, with write access on the repository, requires you to read the <a href="https://github.com/DarwinNE/FidoCadJ/blob/master/README">README</a> file, and discuss a little with the other developers on the <a href="https://sourceforge.net/p/fidocadj/discussion/?source=navbar">Sourceforge web forum</a>.</p>
 			<a class="go_top_label" href="#top">top</a>
 
-			<p>August, 11, 2015</p><br>
+			<p>August, 17, 2015</p><br>
 
 			<h3>License</h3>
 			<img src="images/logos/gplv3-127x51.png" alt="GPL v. 3" class="float">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 		<link href="db_style.css" rel="stylesheet">
 		<meta charset="UTF-8">
 		<meta name=viewport content="width=device-width, initial-scale=1">
+		<meta name="description" content="FidoCadJ is a free user-friendly vector graphic editor for MacOSX, Linux, Windows and Android. Available in English, French, Italian, German, Chinese, Spanish, Czech, Japanese and Dutch">
 		<link rel="icon" href="images/FidoCadJ_favicon.png" />
 		<title>FidoCadJ Free Graphical Editor for Electronics and more</title>
 	</head>
@@ -58,7 +59,7 @@
 				Watercolor by Carlo Maria Manenti.
 			</p>
 
-			<p>April 21, 2015</p><br>
+			<p>August 17, 2015</p><br>
 
 
 			<h3>License</h3>

--- a/libs.html
+++ b/libs.html
@@ -5,6 +5,7 @@
 		<link href="db_style.css" rel="stylesheet">
 		<meta charset="UTF-8">
 		<meta name=viewport content="width=device-width, initial-scale=1">
+		<meta name="description" content="FidoCadJ libreries and symbols collection is also for free. With this user-contributed content you can expand the software capabilities.">
 		<link rel="icon" href="images/FidoCadJ_favicon.png" />
 		<title>FidoCadJ Libraries and Symbols</title>
 	</head>
@@ -300,7 +301,7 @@
 
 			<p>If you have prepared a library file for FidoCadJ or FidoCad and you want to share it between the user community, please, participate to the FidoCadJ forum on Sourceforge. On the other hand, if you have found here something which should <b>not</b> be here, please also write a message on the Sourceforge forum or <a href="mailto:davbucciAVOIDSPAM@tiscali.it"> contact the webmaster by email</a>, eliminating the capital letters in the address.
 
-			<p>February, 27, 2015</p><br>
+			<p>August, 17, 2015</p><br>
 
 			<h3>License</h3>
 			<img src="images/logos/gplv3-127x51.png" alt="GPL v. 3" class="float">

--- a/scrn.html
+++ b/scrn.html
@@ -5,6 +5,7 @@
 		<link href="db_style.css" rel="stylesheet">
 		<meta charset="UTF-8">
 		<meta name=viewport content="width=device-width, initial-scale=1">
+		<meta name="description" content="Some screenshots and examples from FidoCadJ software usage. Use FidoCadJ for technical draw and to make art sketches!">
 		<link rel="icon" href="images/FidoCadJ_favicon.png" />
 		<title>FidoCadJ Screenshots</title>
 	</head>
@@ -77,7 +78,7 @@
 
 				<br>
 
-			<p>October, 5, 2014</p><br>
+			<p>August, 17, 2015</p><br>
 
 			<h3>License</h3>
 			<img src="images/logos/gplv3-127x51.png" alt="GPL v. 3" class="float">


### PR DESCRIPTION
Simply added the Meta tag "description" to the code. That allow us to
choose (or hopefully choose) the content of the text visible on the SERP
under the title.

If is not defined from the code, the search engine will abtract an
arbitrary part of text. Not always the best.