### PR TITLE
Add german translation for margins-related terms

### DIFF
--- a/bin/MessagesBundle_de.properties
+++ b/bin/MessagesBundle_de.properties
@@ -244,9 +244,9 @@ LABEL_EXPLORER_BUTTON=Ordner auswählen
 # not clear the context
 Duplicate=Duplizieren
 
-TopMargin=Top margin (cm)
-BottomMargin=Bottom margin (cm)
-LeftMargin=Left margin (cm)
-RightMargin=Right margin (cm)
-Margins_too_large=Margins are too large!
-Print_outside_regions=Margins are such that the drawing will be printed in regions that are outside the printable area of your printer. Continue anyway?
+TopMargin=Oberer Rand (cm)
+BottomMargin=Unterer Rand (cm)
+LeftMargin=Linker Rand (cm)
+RightMargin=Rechter Rand (cm)
+Margins_too_large=Die Ränder sind zu breit!
+Print_outside_regions=Die Ränder sind so eingestellt, dass die Zeichnung sich ausserhalb des Druckbereichs Ihres Druckers befindet. Trotzdem fortfahren?


### PR DESCRIPTION
As requested, the new terms have been translated. The "Print_outside_regions" is no literal translation of the original but has the same meaning and it fits better the German language.