### PR TITLE
Improved dev tools and fixed javadoc generating errors.

### DIFF
--- a/OSes/android/fidocadj/README.md
+++ b/OSes/android/fidocadj/README.md
@@ -47,7 +47,7 @@ of the Swing application.
 2 - Resources
 =============
 
-The primary resources are always those for the Swing application. For this 
+The primary resources are always those for the Swing application. For this
 reason, if you need to add a string, modify the resource files of the
 Swing application (`/bin/*.resources`) and then run the `res.sh` script.
 
@@ -90,11 +90,11 @@ See the `README.md` file for the Swing application for the complete list of
 acknowledgments. Here we just deal with the specific Android coding.
 
 Code
-:   Davide Bucci, dantecpp, Giuseppe Amato
+:   Davide Bucci, Dante Loi, Giuseppe Amato
 
-When possible, the authors of the snippets have been contacted to gain 
-explicit permission of using the code in an open source project. If you own 
-the copyright of some of the reused code and you do not agree on its 
+When possible, the authors of the snippets have been contacted to gain
+explicit permission of using the code in an open source project. If you own
+the copyright of some of the reused code and you do not agree on its
 inclusion in the FidoCadJ project, open an Issue on GitHub and we will remove
 the offending code as fast as we can.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ using Git from the GitHub repository.
 | `gpl-3.0.txt`        |     | GNU General Public Licence version 3            |
 | `icons/`             |  X  | All icons (made with Gimp)                      |
 | `jar/`               |  X  | Directory for jar and manifest files            |
+| `makefile`           |     | Roles file for the make build system            |
 | `manual/`            |  X  | All the LaTeX manuals sources                   |
 | `NEWS.txt`           |     | The big news, for each version tagged           |
 | `OSes/`              |  X  | Specific things for some OSes; Android app here |
@@ -215,7 +216,6 @@ run and test FidoCadJ.
 | `fidocadj_pmd.html`  | Current result of pmd checks                    |
 | `pmd.sh`             | Launch pmd for warnings and copy/paste detector |
 | `profile`            | Launch a profiler (jip)                         |
-| `rebuild`            | Do a clean and then run FidoCadJ                |
 | `rules.xml`          | Set of coding style rules for Checklist         |
 | `run`                | Run FidoCadJ                                    |
 | `sign.sh`            | Create the signature for the applet             |
@@ -238,7 +238,8 @@ following script to create a JAR archive in the `jar/` directory:
 ---------------------------------------------------
 
 The provided scripts do not work on Microsoft Windows.
-Kohta Ozaki has written a build/run script for Windows, called `winbuild.bat`.
+Kohta Ozaki has written a build/run script for Windows, called
+`dev_tools/winbuild.bat`.
 It must be used with the action to be accomplished, as an argument:
 
 | Argument  | Description                                     |
@@ -587,7 +588,7 @@ https://github.com/DarwinNE/FidoCadJ/issues
 ===================
 
 Code
-:   Davide Bucci, josmil1, phylum2, Kohta Ozaki, dantecpp, miklos80
+:   Davide Bucci, josmil1, phylum2, Kohta Ozaki, Dante Loi, miklos80
 
 Beta testers
 :   Kagliostro, Bruno Valente, simo85, Stefano Martini, F. Bertolazzi,

--- a/dev_tools/clean
+++ b/dev_tools/clean
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-(cd bin
- find . -name *.class -delete
-)
+find bin/ -name *.class -delete

--- a/dev_tools/cleanall
+++ b/dev_tools/cleanall
@@ -1,42 +1,10 @@
 #!/bin/bash
 
-rm  doc/*.*
-rm  jar/fidocadj.jar
-rm  doc/circuit/*.* 
-rm  doc/circuit/controllers/*.*
-rm  doc/clipboard/*.* 
-rm  doc/dialogs/*.*
-rm  doc/export/*.*
-rm  doc/geom/*.*
-rm  doc/globals/*.* 
-rm  doc/layers/*.*
-rm  doc/primitives/*.* 
-rm  doc/timer/*.*
-rm  doc/toolbars/*.*
-rm  doc/undo/*.*
-rm  doc/package-list
+find doc/ -name *.html -delete
 
-rm  doc/net/sourceforge/fidocadj/*.*
-rm  doc/net/sourceforge/fidocadj/layermodel/*.*
-rm  doc/net/sourceforge/fidocadj/librarymodel/*.*
-rm  doc/net/sourceforge/fidocadj/macropicker/*.*
+find bin/ -name *.class -delete
 
-
-rm  bin/*.class
-rm  bin/net/sourceforge/fidocadj/*.class
-rm  bin/net/sourceforge/fidocadj/layermodel/*.class
-rm  bin/net/sourceforge/fidocadj/librarymodel/*.class
-rm  bin/net/sourceforge/fidocadj/macropicker/*.class
-rm  bin/net/sourceforge/fidocadj/circuit/*.class
-rm  bin/net/sourceforge/fidocadj/circuit/controllers/*.class
-rm  bin/net/sourceforge/fidocadj/clipboard/*.class
-rm  bin/net/sourceforge/fidocadj/dialogs/*.class
-rm  bin/net/sourceforge/fidocadj/export/*.class
-rm  bin/net/sourceforge/fidocadj/geom/*.class
-rm  bin/net/sourceforge/fidocadj/globals/*.class
-rm  bin/net/sourceforge/fidocadj/layers/*.class
-rm  bin/net/sourceforge/fidocadj/primitives/*.class
-rm  bin/net/sourceforge/fidocadj/timer/*.class
-rm  bin/net/sourceforge/fidocadj/toolbars/*.class
-rm  bin/net/sourceforge/fidocadj/undo/*.class
-
+if test -e jar/fidocadj.jar
+then
+    rm  jar/fidocadj.jar
+fi

--- a/makefile
+++ b/makefile
@@ -11,31 +11,28 @@ VERSION = 0.24.6
 		rebuild   \		# Do a clean and then run FidoCadJ
 		install			# Install FidoCadJ
 
-default: | cleanall  		\
-		   compile $(ARGS)  \
-		   createjar 		\
-		   clean
+default: compile
 
 compile:
-	./dev_tools/compile
+	@./dev_tools/compile  $(ARGS)
 
 createjar:
-	./dev_tools/createjar
+	@./dev_tools/createjar
 
 createdoc:
-	./dev_tools/createdoc
+	@./dev_tools/createdoc
 
 clean:
-	./dev_tools/clean
+	@./dev_tools/clean
 
 cleanall:
-	./dev_tools/cleanall
+	@./dev_tools/cleanall
 
-rebuild: | clean   			\
-		   compile $(ARGS)	\
+rebuild: | clean   	\
+		   compile 	\
 		   run
 run:
-	./dev_tools/run $(ARGS)
+	@./dev_tools/run $(ARGS)
 
-install:
-	./OSes/linux/install
+install: createjar
+	@./OSes/linux/install

--- a/src/net/sourceforge/fidocadj/AppleSpecific.java
+++ b/src/net/sourceforge/fidocadj/AppleSpecific.java
@@ -39,7 +39,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2009-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/CommandLineParser.java
+++ b/src/net/sourceforge/fidocadj/CommandLineParser.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/DragDropTools.java
+++ b/src/net/sourceforge/fidocadj/DragDropTools.java
@@ -6,7 +6,7 @@ import java.awt.datatransfer.*;
 
 /** DragDropTools.java
 
-    Class handling the drag & drop operations.
+    Class handling the drag and drop operations.
 
     TODO: improve the descriptions in the Javadoc comments. Sometimes are
     cryptical or uninformative.
@@ -25,7 +25,8 @@ import java.awt.datatransfer.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>
@@ -37,7 +38,7 @@ public class DragDropTools implements DropTargetListener
     FidoFrame fff;
 
     /** Constructor.
-        @param f the frame to which the drag&drop tools should be associated.
+      @param f the frame to which the drag and drop tools should be associated.
     */
     public DragDropTools(FidoFrame f)
     {

--- a/src/net/sourceforge/fidocadj/ExportTools.java
+++ b/src/net/sourceforge/fidocadj/ExportTools.java
@@ -29,7 +29,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/FidoCadApplet.java
+++ b/src/net/sourceforge/fidocadj/FidoCadApplet.java
@@ -30,7 +30,8 @@ This is the main file for the FidoCadJ reader applet.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright march 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/FidoFrame.java
+++ b/src/net/sourceforge/fidocadj/FidoFrame.java
@@ -56,7 +56,8 @@ The class describing the main frame in which FidoCadJ runs.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/FidoMain.java
+++ b/src/net/sourceforge/fidocadj/FidoMain.java
@@ -35,7 +35,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2016 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/FidoReadApplet.java
+++ b/src/net/sourceforge/fidocadj/FidoReadApplet.java
@@ -46,7 +46,8 @@ Version   Date           Author       Remarks
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright march 2007 - 2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/FileTools.java
+++ b/src/net/sourceforge/fidocadj/FileTools.java
@@ -27,7 +27,8 @@ import net.sourceforge.fidocadj.export.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/MenuTools.java
+++ b/src/net/sourceforge/fidocadj/MenuTools.java
@@ -30,7 +30,8 @@ import net.sourceforge.fidocadj.clipboard.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/OpenFile.java
+++ b/src/net/sourceforge/fidocadj/OpenFile.java
@@ -24,7 +24,8 @@ import java.awt.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2012-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/PrintTools.java
+++ b/src/net/sourceforge/fidocadj/PrintTools.java
@@ -36,7 +36,8 @@ import net.sourceforge.fidocadj.layers.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/RunExport.java
+++ b/src/net/sourceforge/fidocadj/RunExport.java
@@ -27,7 +27,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2012-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/ScrollGestureRecognizer.java
+++ b/src/net/sourceforge/fidocadj/ScrollGestureRecognizer.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.toolbars.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
     Copyright 2007-2016 Santhosh Kumar T, Davide Bucci
     </pre>
 */

--- a/src/net/sourceforge/fidocadj/circuit/CircuitPanel.java
+++ b/src/net/sourceforge/fidocadj/circuit/CircuitPanel.java
@@ -45,7 +45,8 @@ import net.sourceforge.fidocadj.layers.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/HasChangedListener.java
+++ b/src/net/sourceforge/fidocadj/circuit/HasChangedListener.java
@@ -15,7 +15,8 @@ package net.sourceforge.fidocadj.circuit;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     </pre>
     @version 1.0

--- a/src/net/sourceforge/fidocadj/circuit/MouseMoveClickHandler.java
+++ b/src/net/sourceforge/fidocadj/circuit/MouseMoveClickHandler.java
@@ -30,7 +30,8 @@ import net.sourceforge.fidocadj.geom.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/MouseWheelHandler.java
+++ b/src/net/sourceforge/fidocadj/circuit/MouseWheelHandler.java
@@ -24,7 +24,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by miklos80, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/PopUpMenu.java
+++ b/src/net/sourceforge/fidocadj/circuit/PopUpMenu.java
@@ -28,7 +28,8 @@ import net.sourceforge.fidocadj.clipboard.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/Ruler.java
+++ b/src/net/sourceforge/fidocadj/circuit/Ruler.java
@@ -22,7 +22,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/AddElements.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/AddElements.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/ContinuosMoveActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/ContinuosMoveActions.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.primitives.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/CopyPasteActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/CopyPasteActions.java
@@ -21,7 +21,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/EditorActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/EditorActions.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.primitives.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/ElementsEdtActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/ElementsEdtActions.java
@@ -31,7 +31,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/HandleActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/HandleActions.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2016 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/ParserActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/ParserActions.java
@@ -33,7 +33,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/PrimitivesParInterface.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/PrimitivesParInterface.java
@@ -18,7 +18,8 @@ package net.sourceforge.fidocadj.circuit.controllers;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/SelectionActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/SelectionActions.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.primitives.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/controllers/UndoActions.java
+++ b/src/net/sourceforge/fidocadj/circuit/controllers/UndoActions.java
@@ -27,7 +27,8 @@ import net.sourceforge.fidocadj.undo.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/model/DrawingModel.java
+++ b/src/net/sourceforge/fidocadj/circuit/model/DrawingModel.java
@@ -29,7 +29,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/model/ProcessElementsInterface.java
+++ b/src/net/sourceforge/fidocadj/circuit/model/ProcessElementsInterface.java
@@ -18,7 +18,8 @@ import net.sourceforge.fidocadj.primitives.GraphicPrimitive;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/circuit/views/Drawing.java
+++ b/src/net/sourceforge/fidocadj/circuit/views/Drawing.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/circuit/views/Export.java
+++ b/src/net/sourceforge/fidocadj/circuit/views/Export.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.primitives.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/clipboard/TextTransfer.java
+++ b/src/net/sourceforge/fidocadj/clipboard/TextTransfer.java
@@ -28,7 +28,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
    </pre>
 

--- a/src/net/sourceforge/fidocadj/dialogs/ArrowCellRenderer.java
+++ b/src/net/sourceforge/fidocadj/dialogs/ArrowCellRenderer.java
@@ -25,7 +25,9 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
+    
     </pre>
 
     Copyright 2009-2010 by Davide Bucci

--- a/src/net/sourceforge/fidocadj/dialogs/ArrowInfo.java
+++ b/src/net/sourceforge/fidocadj/dialogs/ArrowInfo.java
@@ -21,7 +21,8 @@ import net.sourceforge.fidocadj.primitives.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2009 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/CellArrow.java
+++ b/src/net/sourceforge/fidocadj/dialogs/CellArrow.java
@@ -31,7 +31,8 @@ import net.sourceforge.fidocadj.graphic.swing.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2009-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/CellDash.java
+++ b/src/net/sourceforge/fidocadj/dialogs/CellDash.java
@@ -31,7 +31,8 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
     </pre>
 
     Copyright 2009-2014 by Davide Bucci

--- a/src/net/sourceforge/fidocadj/dialogs/CellLayer.java
+++ b/src/net/sourceforge/fidocadj/dialogs/CellLayer.java
@@ -32,7 +32,8 @@ import net.sourceforge.fidocadj.graphic.swing.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
     </pre>
 
     Copyright 2007-2015 by Davide Bucci

--- a/src/net/sourceforge/fidocadj/dialogs/DashCellRenderer.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DashCellRenderer.java
@@ -27,7 +27,8 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2009 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DashInfo.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DashInfo.java
@@ -21,7 +21,8 @@ import net.sourceforge.fidocadj.primitives.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2009-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogAbout.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogAbout.java
@@ -35,7 +35,8 @@ import net.sourceforge.fidocadj.dialogs.mindimdialog.MinimumSizeDialog;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogEditLayer.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogEditLayer.java
@@ -34,7 +34,8 @@ import net.sourceforge.fidocadj.dialogs.mindimdialog.MinimumSizeDialog;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2010 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogExport.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogExport.java
@@ -30,7 +30,8 @@ import net.sourceforge.fidocadj.dialogs.mindimdialog.MinimumSizeDialog;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogLayer.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogLayer.java
@@ -29,7 +29,8 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogOptions.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogOptions.java
@@ -31,7 +31,8 @@ import net.sourceforge.fidocadj.dialogs.mindimdialog.MinimumSizeDialog;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogParameters.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogParameters.java
@@ -35,7 +35,8 @@ import net.sourceforge.fidocadj.dialogs.mindimdialog.MinimumSizeDialog;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogSymbolize.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogSymbolize.java
@@ -50,7 +50,8 @@ import javax.swing.border.Border;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2012-2015 Phylum2, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/DialogUtil.java
+++ b/src/net/sourceforge/fidocadj/dialogs/DialogUtil.java
@@ -24,7 +24,8 @@ import net.sourceforge.fidocadj.globals.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2013 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/EnterCircuitFrame.java
+++ b/src/net/sourceforge/fidocadj/dialogs/EnterCircuitFrame.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.dialogs.mindimdialog.MinimumSizeDialog;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2012 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/LayerCellRenderer.java
+++ b/src/net/sourceforge/fidocadj/dialogs/LayerCellRenderer.java
@@ -26,7 +26,8 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
     </pre>
 
     @author Davide Bucci

--- a/src/net/sourceforge/fidocadj/dialogs/LayerInfo.java
+++ b/src/net/sourceforge/fidocadj/dialogs/LayerInfo.java
@@ -18,7 +18,8 @@ import net.sourceforge.fidocadj.layers.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2009 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/OSKeybPanel.java
+++ b/src/net/sourceforge/fidocadj/dialogs/OSKeybPanel.java
@@ -50,7 +50,8 @@ import net.sourceforge.fidocadj.globals.Globals;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2012-2014 by phylum2, Davide Bucci
 

--- a/src/net/sourceforge/fidocadj/dialogs/OriginCircuitPanel.java
+++ b/src/net/sourceforge/fidocadj/dialogs/OriginCircuitPanel.java
@@ -41,7 +41,8 @@ import javax.swing.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2012-2015 Phylum2, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/ParameterDescription.java
+++ b/src/net/sourceforge/fidocadj/dialogs/ParameterDescription.java
@@ -18,7 +18,8 @@ package net.sourceforge.fidocadj.dialogs;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/mindimdialog/MinimumSizeDialog.java
+++ b/src/net/sourceforge/fidocadj/dialogs/mindimdialog/MinimumSizeDialog.java
@@ -18,7 +18,8 @@ import java.awt.event.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/dialogs/print/DialogPrint.java
+++ b/src/net/sourceforge/fidocadj/dialogs/print/DialogPrint.java
@@ -37,7 +37,8 @@ import net.sourceforge.fidocadj.layers.LayerDesc;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
 </pre>
@@ -558,8 +559,8 @@ public class DialogPrint extends MinimumSizeDialog
     }
 
     /** Get the layer to be printed if a single layer is what the user need.
-        @return the layer to be printed if >=0 or -1 if all layers should be
-            printed.
+        @return the layer to be printed if greater or equal than 0 or -1 if all
+            layers should be printed.
     */
     public int getSingleLayerToPrint()
     {

--- a/src/net/sourceforge/fidocadj/dialogs/print/PrintPreview.java
+++ b/src/net/sourceforge/fidocadj/dialogs/print/PrintPreview.java
@@ -33,7 +33,8 @@ import net.sourceforge.fidocadj.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportEPS.java
+++ b/src/net/sourceforge/fidocadj/export/ExportEPS.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportEagle.java
+++ b/src/net/sourceforge/fidocadj/export/ExportEagle.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
    </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportFidoCad.java
+++ b/src/net/sourceforge/fidocadj/export/ExportFidoCad.java
@@ -30,7 +30,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportGraphic.java
+++ b/src/net/sourceforge/fidocadj/export/ExportGraphic.java
@@ -43,7 +43,8 @@ import java.lang.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportInterface.java
+++ b/src/net/sourceforge/fidocadj/export/ExportInterface.java
@@ -35,7 +35,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
    </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportPDF.java
+++ b/src/net/sourceforge/fidocadj/export/ExportPDF.java
@@ -30,7 +30,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportPGF.java
+++ b/src/net/sourceforge/fidocadj/export/ExportPGF.java
@@ -48,7 +48,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/export/ExportSVG.java
+++ b/src/net/sourceforge/fidocadj/export/ExportSVG.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/geom/ChangeCoordinatesListener.java
+++ b/src/net/sourceforge/fidocadj/geom/ChangeCoordinatesListener.java
@@ -20,7 +20,8 @@ package net.sourceforge.fidocadj.geom;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/geom/DrawingSize.java
+++ b/src/net/sourceforge/fidocadj/geom/DrawingSize.java
@@ -27,7 +27,8 @@ import net.sourceforge.fidocadj.graphic.nil.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/geom/GeometricDistances.java
+++ b/src/net/sourceforge/fidocadj/geom/GeometricDistances.java
@@ -19,7 +19,8 @@ package net.sourceforge.fidocadj.geom;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2016 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/geom/MapCoordinates.java
+++ b/src/net/sourceforge/fidocadj/geom/MapCoordinates.java
@@ -19,7 +19,8 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/globals/AccessResources.java
+++ b/src/net/sourceforge/fidocadj/globals/AccessResources.java
@@ -24,7 +24,7 @@ import java.io.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see http://www.gnu.org/licenses/
+    along with FidoCadJ. If not,  If not, see http://www.gnu.org/licenses/
 
     Copyright 2014 by Davide Bucci
 

--- a/src/net/sourceforge/fidocadj/globals/FileUtils.java
+++ b/src/net/sourceforge/fidocadj/globals/FileUtils.java
@@ -21,7 +21,8 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/globals/Globals.java
+++ b/src/net/sourceforge/fidocadj/globals/Globals.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
 
@@ -327,7 +328,7 @@ public class Globals
 
         @param p the input string, eventually containing the characters to be
             changed.
-        @param bc an hash table <char, String> in which each character to be
+        @param bc an hash table (char, String) in which each character to be
             changed is associated with its code, or escape sequence.
         @return the string with the characters changed.
 

--- a/src/net/sourceforge/fidocadj/globals/LibUtils.java
+++ b/src/net/sourceforge/fidocadj/globals/LibUtils.java
@@ -37,7 +37,8 @@ import net.sourceforge.fidocadj.FidoMain;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2012-2014 by phylum2, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/globals/ProvidesCopyPasteInterface.java
+++ b/src/net/sourceforge/fidocadj/globals/ProvidesCopyPasteInterface.java
@@ -17,7 +17,8 @@ package net.sourceforge.fidocadj.globals;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
 

--- a/src/net/sourceforge/fidocadj/graphic/ColorInterface.java
+++ b/src/net/sourceforge/fidocadj/graphic/ColorInterface.java
@@ -22,7 +22,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/DimensionG.java
+++ b/src/net/sourceforge/fidocadj/graphic/DimensionG.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/graphic/FontG.java
+++ b/src/net/sourceforge/fidocadj/graphic/FontG.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/graphic/GraphicsInterface.java
+++ b/src/net/sourceforge/fidocadj/graphic/GraphicsInterface.java
@@ -19,7 +19,8 @@ import net.sourceforge.fidocadj.layers.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/graphic/PointDouble.java
+++ b/src/net/sourceforge/fidocadj/graphic/PointDouble.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/graphic/PointG.java
+++ b/src/net/sourceforge/fidocadj/graphic/PointG.java
@@ -17,7 +17,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/PolygonInterface.java
+++ b/src/net/sourceforge/fidocadj/graphic/PolygonInterface.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/RectangleG.java
+++ b/src/net/sourceforge/fidocadj/graphic/RectangleG.java
@@ -17,7 +17,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/ShapeInterface.java
+++ b/src/net/sourceforge/fidocadj/graphic/ShapeInterface.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.graphic;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/nil/ColorNull.java
+++ b/src/net/sourceforge/fidocadj/graphic/nil/ColorNull.java
@@ -22,7 +22,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/nil/GraphicsNull.java
+++ b/src/net/sourceforge/fidocadj/graphic/nil/GraphicsNull.java
@@ -32,7 +32,8 @@ import net.sourceforge.fidocadj.layers.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/nil/PolygonNull.java
+++ b/src/net/sourceforge/fidocadj/graphic/nil/PolygonNull.java
@@ -24,7 +24,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/nil/ShapeNull.java
+++ b/src/net/sourceforge/fidocadj/graphic/nil/ShapeNull.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/graphic/swing/ColorSwing.java
+++ b/src/net/sourceforge/fidocadj/graphic/swing/ColorSwing.java
@@ -22,7 +22,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/swing/Graphics2DSwing.java
+++ b/src/net/sourceforge/fidocadj/graphic/swing/Graphics2DSwing.java
@@ -30,7 +30,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/graphic/swing/PolygonSwing.java
+++ b/src/net/sourceforge/fidocadj/graphic/swing/PolygonSwing.java
@@ -19,7 +19,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/graphic/swing/ShapeSwing.java
+++ b/src/net/sourceforge/fidocadj/graphic/swing/ShapeSwing.java
@@ -22,7 +22,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 by Davide Bucci
 </pre>

--- a/src/net/sourceforge/fidocadj/layermodel/LayerModel.java
+++ b/src/net/sourceforge/fidocadj/layermodel/LayerModel.java
@@ -11,7 +11,8 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+// along with FidoCadJ. If not,
+//	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 //
 // Copyright 2014 Kohta Ozaki
 

--- a/src/net/sourceforge/fidocadj/layers/LayerDesc.java
+++ b/src/net/sourceforge/fidocadj/layers/LayerDesc.java
@@ -20,7 +20,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2015 by Davide Bucci
 

--- a/src/net/sourceforge/fidocadj/layers/StandardLayers.java
+++ b/src/net/sourceforge/fidocadj/layers/StandardLayers.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.swing.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
 

--- a/src/net/sourceforge/fidocadj/librarymodel/Category.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/Category.java
@@ -20,7 +20,8 @@ import net.sourceforge.fidocadj.primitives.MacroDesc;
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+   along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
    Copyright 2014 Kohta Ozaki
 */

--- a/src/net/sourceforge/fidocadj/librarymodel/Library.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/Library.java
@@ -18,7 +18,8 @@ import java.util.*;
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+   along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
    Copyright 2014 Kohta Ozaki
 */

--- a/src/net/sourceforge/fidocadj/librarymodel/LibraryModel.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/LibraryModel.java
@@ -29,7 +29,8 @@ import net.sourceforge.fidocadj.primitives.MacroDesc;
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+   along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
    Copyright 2014 Kohta Ozaki
 */

--- a/src/net/sourceforge/fidocadj/librarymodel/event/AddEvent.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/event/AddEvent.java
@@ -15,7 +15,8 @@ package net.sourceforge.fidocadj.librarymodel.event;
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+   along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
    Copyright 2014 Kohta Ozaki
 */

--- a/src/net/sourceforge/fidocadj/librarymodel/event/KeyChangeEvent.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/event/KeyChangeEvent.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.librarymodel.event;
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+   along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
    Copyright 2014 Kohta Ozaki
 */

--- a/src/net/sourceforge/fidocadj/librarymodel/event/LibraryListener.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/event/LibraryListener.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.librarymodel.event;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/librarymodel/event/LibraryListenerAdapter.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/event/LibraryListenerAdapter.java
@@ -17,7 +17,8 @@ package net.sourceforge.fidocadj.librarymodel.event;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/librarymodel/event/RemoveEvent.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/event/RemoveEvent.java
@@ -15,7 +15,8 @@ package net.sourceforge.fidocadj.librarymodel.event;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/librarymodel/event/RenameEvent.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/event/RenameEvent.java
@@ -15,7 +15,8 @@ package net.sourceforge.fidocadj.librarymodel.event;
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+   along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
    Copyright 2014 Kohta Ozaki
 */

--- a/src/net/sourceforge/fidocadj/librarymodel/utils/CircuitPanelUpdater.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/utils/CircuitPanelUpdater.java
@@ -28,7 +28,8 @@ import net.sourceforge.fidocadj.FidoFrame;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/librarymodel/utils/LibraryUndoExecutor.java
+++ b/src/net/sourceforge/fidocadj/librarymodel/utils/LibraryUndoExecutor.java
@@ -27,7 +27,8 @@ import net.sourceforge.fidocadj.FidoFrame;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/ExpandableJTree.java
+++ b/src/net/sourceforge/fidocadj/macropicker/ExpandableJTree.java
@@ -23,7 +23,8 @@ import java.awt.Graphics;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 Kohta Ozaki, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/MacroTree.java
+++ b/src/net/sourceforge/fidocadj/macropicker/MacroTree.java
@@ -47,7 +47,8 @@ import net.sourceforge.fidocadj.primitives.MacroDesc;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/MacroTreeCellRenderer.java
+++ b/src/net/sourceforge/fidocadj/macropicker/MacroTreeCellRenderer.java
@@ -44,7 +44,8 @@ import net.sourceforge.fidocadj.primitives.MacroDesc;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 Kohta Ozaki, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/MacroTreePopupMenu.java
+++ b/src/net/sourceforge/fidocadj/macropicker/MacroTreePopupMenu.java
@@ -28,7 +28,8 @@ import net.sourceforge.fidocadj.primitives.MacroDesc;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/OperationPermissions.java
+++ b/src/net/sourceforge/fidocadj/macropicker/OperationPermissions.java
@@ -42,7 +42,8 @@ import net.sourceforge.fidocadj.primitives.MacroDesc;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2015 Kohta Ozaki, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/model/AbstractMacroTreeNode.java
+++ b/src/net/sourceforge/fidocadj/macropicker/model/AbstractMacroTreeNode.java
@@ -19,7 +19,9 @@ import javax.swing.tree.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,
+    
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014-2016 Kohta Ozaki, Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/model/MacroTreeModel.java
+++ b/src/net/sourceforge/fidocadj/macropicker/model/MacroTreeModel.java
@@ -32,7 +32,8 @@ import net.sourceforge.fidocadj.primitives.MacroDesc;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/model/MacroTreeNode.java
+++ b/src/net/sourceforge/fidocadj/macropicker/model/MacroTreeNode.java
@@ -19,7 +19,8 @@ import javax.swing.tree.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/macropicker/model/NodeFilterInterface.java
+++ b/src/net/sourceforge/fidocadj/macropicker/model/NodeFilterInterface.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.macropicker.model;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2014 Kohta Ozaki
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/Arrow.java
+++ b/src/net/sourceforge/fidocadj/primitives/Arrow.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2009-2015 by Davide Bucci
    </pre>

--- a/src/net/sourceforge/fidocadj/primitives/GraphicPrimitive.java
+++ b/src/net/sourceforge/fidocadj/primitives/GraphicPrimitive.java
@@ -28,7 +28,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2016 by Davide Bucci, phylum2
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/MacroDesc.java
+++ b/src/net/sourceforge/fidocadj/primitives/MacroDesc.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.primitives;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2013 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveAdvText.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveAdvText.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.graphic.nil.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveBezier.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveBezier.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveComplexCurve.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveComplexCurve.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2011-2016 by Davide Bucci
 

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveConnection.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveConnection.java
@@ -24,7 +24,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveLine.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveLine.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveMacro.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveMacro.java
@@ -32,7 +32,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveOval.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveOval.java
@@ -26,7 +26,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitivePCBLine.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitivePCBLine.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitivePCBPad.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitivePCBPad.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitivePolygon.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitivePolygon.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/primitives/PrimitiveRectangle.java
+++ b/src/net/sourceforge/fidocadj/primitives/PrimitiveRectangle.java
@@ -25,7 +25,8 @@ import net.sourceforge.fidocadj.graphic.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/timer/MyTimer.java
+++ b/src/net/sourceforge/fidocadj/timer/MyTimer.java
@@ -30,7 +30,8 @@ Version   Date                Author       Remarks
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/toolbars/ChangeGridState.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ChangeGridState.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.toolbars;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/toolbars/ChangeSelectedLayer.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ChangeSelectedLayer.java
@@ -15,7 +15,8 @@ package net.sourceforge.fidocadj.toolbars;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/toolbars/ChangeSelectionListener.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ChangeSelectionListener.java
@@ -16,7 +16,8 @@ package net.sourceforge.fidocadj.toolbars;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/toolbars/ChangeZoomListener.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ChangeZoomListener.java
@@ -19,7 +19,8 @@ package net.sourceforge.fidocadj.toolbars;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/toolbars/ToolButton.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ToolButton.java
@@ -37,12 +37,13 @@ import java.net.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
     </pre>
 
-    @author Davide Bucci & Jose Emilio Munoz
+    @author Davide Bucci, Jose Emilio Munoz
 
 */
 

--- a/src/net/sourceforge/fidocadj/toolbars/ToolbarTools.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ToolbarTools.java
@@ -50,11 +50,12 @@ import java.net.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
     </pre>
- @author Davide Bucci & Jose Emilio Munoz
+ @author Davide Bucci, Jose Emilio Munoz
 */
 
 public class ToolbarTools extends JToolBar implements ChangeSelectionListener

--- a/src/net/sourceforge/fidocadj/toolbars/ToolbarZoom.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ToolbarZoom.java
@@ -30,7 +30,8 @@ import net.sourceforge.fidocadj.layers.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2007-2016 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/toolbars/ZoomToFitListener.java
+++ b/src/net/sourceforge/fidocadj/toolbars/ZoomToFitListener.java
@@ -18,7 +18,8 @@ package net.sourceforge.fidocadj.toolbars;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2012 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/undo/LibraryUndoListener.java
+++ b/src/net/sourceforge/fidocadj/undo/LibraryUndoListener.java
@@ -17,7 +17,8 @@ package net.sourceforge.fidocadj.undo;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/undo/UndoActorListener.java
+++ b/src/net/sourceforge/fidocadj/undo/UndoActorListener.java
@@ -17,7 +17,8 @@ package net.sourceforge.fidocadj.undo;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/undo/UndoManager.java
+++ b/src/net/sourceforge/fidocadj/undo/UndoManager.java
@@ -24,7 +24,8 @@ import java.io.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2014 by Davide Bucci
     </pre>

--- a/src/net/sourceforge/fidocadj/undo/UndoState.java
+++ b/src/net/sourceforge/fidocadj/undo/UndoState.java
@@ -17,7 +17,8 @@ import java.util.*;
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with FidoCadJ.  If not, see <http://www.gnu.org/licenses/>.
+    along with FidoCadJ. If not,  
+ 	@see <a href=http://www.gnu.org/licenses/>http://www.gnu.org/licenses/</a>.
 
     Copyright 2008-2013 by Davide Bucci
     </pre>


### PR DESCRIPTION
### Change log:

-  `make` works as `make compile`.
- fixed all doc generating errors, discussed in #35.
- improved the `dev_tools/cleanall` and `dev_tools/clean` scripts.

Remember do not use, or correctly escape the special characters `<>"'\&` in the comments. 