### PR TITLE
Replace a.newInstance() with a.getConstructor().newInstance() on line…

### DIFF
--- a/src/net/sourceforge/fidocadj/FidoMain.java
+++ b/src/net/sourceforge/fidocadj/FidoMain.java
@@ -454,7 +454,7 @@ class CreateSwingInterface implements Runnable
             try {
                 Class<?> a = Class.forName(
                     "net.sourceforge.fidocadj.AppleSpecific");
-                Object b = a.newInstance();
+                Object b = a.getConstructor().newInstance();
                 Method m = a.getMethod("answerFinder");
                 m.invoke(b);
             } catch (NoClassDefFoundError|ClassNotFoundException|


### PR DESCRIPTION
… 457

Class.newInstance() was deprecated in Java 9. Replacing it with Class.getConstructor().newInstance() allows for compilation with Java 9 and above.