### PR TITLE
Added German translations

### DIFF
--- a/bin/MessagesBundle_de.properties
+++ b/bin/MessagesBundle_de.properties
@@ -267,9 +267,9 @@ res_export = Setze Auflösung in dpi
 size_export = Setze Größe in Pixel
 Split_layers_multiple_files = Teile Ebenen in mehrere Dateien auf
 
-Copy_as_image=Copy all as image
-param_hints=Hints
-param_greek=Greek
-param_misc=Misc
-text_hints=Use "_" to introduce an index or "^" to introduce an exponent. End with the opposite command, i.e. "^" to terminate an index and "_" to terminate an exponent. Type "__" to get a simple underline symbol "_" and "^^" to get a simple caret "^". For example: "3^2_+4^2_=5^2"
-restart_info=If you change the following options, restart FidoCadJ:
+Copy_as_image=Kopiere alle als Bild
+param_hints=Hinweise
+param_greek=Griechisch
+param_misc=Sonstige
+text_hints=Benutze "_" um eine Basis oder "^" um einen Exponenten anzufangen. Beende mit dem gegenteiligen Kommando, also "^" um eine Basis und "_" um einen Exponenten zu terminieren. Gebe "__" ein, um einen einfachen Unterstrich "_" zu erzeugen und "^^" um ein einfaches Caret "^" zu erzeugen. Zum Beispiel: "3^2_+4^2_=5^2"
+restart_info=Wenn du die folgenden Einstellungen änderst, muss FidoCadJ neu gestartet werden:


### PR DESCRIPTION
This PR is work in progress

Fixes #42

I am not sure about the `text_hints`, I think the English text may be wrong. If this is about Exponentiation, the proper terms are **base** and **exponent**, not index. See [here](https://en.wikipedia.org/wiki/Exponentiation). But I couldn't check the exact context of this string, so correct me if I'm wrong.

Also, the example seems incorrect in English. The last exponent (`5^2`) is not terminated. Is this on purpose? If not, it must be fixed in both German and English.